### PR TITLE
PLATUI-2539: Update sbt-test-report plugin to version 0.17.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.16.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.17.0")


### PR DESCRIPTION
- [Update sbt-test-report plugin to version 0.17.0](https://github.com/hmrc/platui-2539-scrs-ui-journey-tests/commit/cb095412cd05bba4c863a525e57915b1e8887a87)