### PR TITLE
PLATUI-2640: Update sbt-test-report plugin version to 0.21.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.19.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.21.0")


### PR DESCRIPTION
- [Update sbt-test-report plugin version to 0.21.0](https://github.com/hmrc/platui-2539-scrs-ui-journey-tests/commit/be662bb13f7d6c22a814ca48755524a02f0c1513)